### PR TITLE
Collin/pair command

### DIFF
--- a/src/cellar_wrapper.rs
+++ b/src/cellar_wrapper.rs
@@ -51,6 +51,23 @@ impl<T: 'static + Middleware> CellarState<T> {
         Ok(())
     }
 
+        // Rebalance portfolio with cellar tick info
+        pub async fn reinvest(&mut self) -> Result<(), Error> {
+
+            let mut call = self.contract.reinvest();
+    
+            if let Some(gas_price) = self.gas_price {
+                call = call.gas_price(gas_price)
+            }
+    
+            let gased = call.gas(5_000_000);
+    
+            let pending = gased.send().await?;
+            dbg!(&pending);
+    
+            Ok(())
+        }
+
     // Add liquidity for uniswap version 3 with values form struct `CellarAddParams`
     pub async fn add_liquidity_for_uni_v3(
         &mut self,

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -26,6 +26,7 @@ mod start;
 mod transfer;
 mod tx;
 mod version;
+mod reinvest;
 
 use self::{
     config_cmd::ConfigCmd, fund_cellar::FundCellarCmd, keys::KeysCmd, predictions::PredictionsCmd,
@@ -99,6 +100,9 @@ pub enum CellarRebalancerCmd {
 
     #[options(help = "Allow Erc20 Token to interact with cellar contract")]
     AllowErc20(allow_erc20::AllowERC20),
+
+    #[options(help = "Reinvest fees on the cellar")]
+    Reinvest(reinvest::ReinvestCommand),
 }
 
 /// This trait allows you to define how application configuration is loaded.

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -13,7 +13,7 @@ use abscissa_core::{Command, Options, Runnable};
 /// for a more comprehensive example:
 ///
 /// <https://docs.rs/gumdrop/>
-#[derive(Command, Debug, Options)]
+#[derive(Command, Debug, Options, Runnable)]
 pub enum QueryCmd {
     Cosmos(cosmos::Cosmos),
     Eth(eth::Eth),
@@ -28,11 +28,4 @@ pub enum QueryCmd {
     // "free" arguments don't have an associated flag
     // #[options(free)]
     // free_args: Vec<String>,
-}
-
-impl Runnable for QueryCmd {
-    /// Start the application.
-    fn run(&self) {
-        // Your code goes here
-    }
 }

--- a/src/commands/query/eth.rs
+++ b/src/commands/query/eth.rs
@@ -1,22 +1,21 @@
 //! `eth subcommands` subcommand
 
+use crate::uniswap_pool::PoolState;
 use crate::{application::APP, prelude::*};
 use abscissa_core::{Command, Options, Runnable};
+use ethers::prelude::*;
+use std::{convert::TryFrom, sync::Arc, time::Duration};
 
-#[derive(Command, Debug, Options)]
+#[derive(Command, Debug, Options, Runnable)]
 pub enum Eth {
     #[options(help = "balance [key-name]")]
     Balance(Balance),
 
     #[options(help = "contract")]
     Contract(Contract),
-}
 
-impl Runnable for Eth {
-    /// Start the application.
-    fn run(&self) {
-        // Your code goes here
-    }
+    #[options(help = "print liquidity pool pair information")]
+    Pair(Pair),
 }
 
 #[derive(Command, Debug, Options)]
@@ -49,4 +48,37 @@ pub struct Contract {
 impl Runnable for Contract {
     /// Start the application.
     fn run(&self) {}
+}
+
+#[derive(Command, Debug, Options)]
+pub struct Pair {
+    #[options(help = "print help message")]
+    help: bool,
+
+    #[options(help = "liquidity pool address", required)]
+    pool: H160,
+}
+
+impl Runnable for Pair {
+    /// Start the application.
+    fn run(&self) {
+        let config = APP.config();
+        let eth_host = config.ethereum.rpc.clone();
+
+        abscissa_tokio::run(&APP, async {
+            let client = Provider::<Http>::try_from(eth_host)
+                .unwrap()
+                .interval(Duration::from_secs(3000u64));
+            let client = Arc::new(client);
+            let pool = PoolState::new(self.pool, client);
+            let (token_0, token_1) = (pool.token_0().await, pool.token_1().await);
+
+            println!("token_0: {:?}", token_0);
+            println!("token_1: {:?}", token_1);
+        })
+        .unwrap_or_else(|e| {
+            status_err!("executor exited with error: {}", e);
+            std::process::exit(1);
+        });
+    }
 }

--- a/src/commands/reinvest.rs
+++ b/src/commands/reinvest.rs
@@ -1,0 +1,74 @@
+use std::{convert::TryFrom, ops::Add, path, sync::Arc, time::Duration};
+
+use abscissa_core::{Application, Command, Options, Runnable};
+use chrono::Utc;
+use ethers::prelude::*;
+use num_bigint::{BigInt, ToBigInt};
+use num_traits::Zero;
+use signatory::FsKeyStore;
+
+use crate::{
+    cellar_wrapper::{CellarAddParams, CellarState, CellarTickInfo},
+    erc20::Erc20State,
+    gas::CellarGas,
+    prelude::*,
+    uniswap_pool::PoolState,
+};
+
+#[derive(Command, Debug, Options)]
+pub struct ReinvestCommand {
+    #[options(help = "Cellar Id")]
+    pub cellar_id: u32,
+}
+
+impl Runnable for ReinvestCommand {
+    fn run(&self) {
+        let config = APP.config();
+        let cellar = config.cellars.get(0).expect("Could not get cellar config");
+
+        let keystore = path::Path::new(&config.keys.keystore);
+        let keystore = FsKeyStore::create_or_open(keystore).expect("Could not open keystore");
+
+        let name = &config
+            .keys
+            .rebalancer_key
+            .parse()
+            .expect("Could not parse name");
+        let key = keystore.load(name).expect("Could not load key");
+
+        let key = key
+            .to_pem()
+            .parse::<k256::elliptic_curve::SecretKey<k256::Secp256k1>>()
+            .expect("Could not parse key");
+
+        let wallet: LocalWallet = Wallet::from(key);
+
+        let eth_host = config.ethereum.rpc.clone();
+        let address = wallet.address();
+
+        abscissa_tokio::run(&APP, async {
+            let client = Provider::<Http>::try_from(eth_host)
+                .unwrap()
+                .interval(Duration::from_secs(3000u64));
+
+            let client = SignerMiddleware::new(client, wallet);
+            let gas = CellarGas::etherscan_standard().await.unwrap();
+
+            // MyContract expects Arc, create with client
+            let client = Arc::new(client);
+
+            let mut contract_state = CellarState::new(cellar.cellar_address, client.clone());
+            contract_state.gas_price = Some(gas);
+   
+
+            contract_state
+                .reinvest()
+                .await
+                .unwrap();
+        })
+        .unwrap_or_else(|e| {
+            status_err!("executor exited with error: {}", e);
+            std::process::exit(1);
+        });
+    }
+}

--- a/src/uniswap_pool.rs
+++ b/src/uniswap_pool.rs
@@ -19,4 +19,21 @@ impl<T: 'static + Middleware> PoolState<T> {
             contract: UPool::new(address, client),
         }
     }
+
+    pub async fn token_0(&self) -> Address {
+        self.contract
+            .token_0()
+            .call()
+            .await
+            .expect("Failed to get token0 address")
+        
+    }
+
+    pub async fn token_1(&self) -> Address {
+        self.contract
+            .token_1()
+            .call()
+            .await
+            .expect("Failed to get token0 address")
+    }
 }


### PR DESCRIPTION
Branch name is a little bit understated:

Includes wrapper methods for the token_0 and token_1 functions in the uniswap_pool ABI. Also mad a `pair` query sub-command to for the cli to print the token addresses of a provided pool address:

```
cargo run -- query eth pair --pool 0x0000000000000whatever
``` 