### PR TITLE
Deploy ERC20 waits longer due to block delay

### DIFF
--- a/steward/src/commands/deploy/erc20.rs
+++ b/steward/src/commands/deploy/erc20.rs
@@ -99,7 +99,7 @@ impl Erc20 {
         println!("We have deployed ERC20 contract at tx hash {}, waiting to see if the Cosmos chain chooses to adopt it",
             format_eth_hash(res));
 
-        match tokio::time::timeout(Duration::from_secs(100), async {
+        match tokio::time::timeout(Duration::from_secs(300), async {
             loop {
                 let req = DenomToErc20Request {
                     denom: denom.clone(),


### PR DESCRIPTION
Based on testing, it may take longer than the existing 100 second timeout to fully deploy an ERC20. This won't cause the deploy to fail, as the timeout is querying the chain state, but it tells the user it failed. To verify it succeeded after a timeout one would need to query the gravity module using `denom_to_erc20` themselves.