### PR TITLE
improve cosmos-signer error handling

### DIFF
--- a/steward/src/allocation.rs
+++ b/steward/src/allocation.rs
@@ -246,8 +246,8 @@ pub async fn direct_rebalance(
     let wallet: LocalWallet = Wallet::from(key);
 
     let eth_host = config.ethereum.rpc.clone();
-    let provider = Provider::<Http>::try_from(eth_host.clone()).unwrap();
-
+    let provider = Provider::<Http>::try_from(eth_host.clone())
+        .unwrap_or_else(|_| panic!("could not get provider from eth_host {}", eth_host));
     let chain_id = provider
         .get_chainid()
         .await

--- a/steward/src/error.rs
+++ b/steward/src/error.rs
@@ -5,6 +5,7 @@ use deep_space::error::{AddressError, CosmosGrpcError, PrivateKeyError};
 use ethers::prelude::{
     errors::EtherscanError, gas_oracle::GasOracleError, ContractError, Middleware, ProviderError,
 };
+use prost::EncodeError;
 use std::{
     fmt::{self, Display},
     io,
@@ -93,6 +94,12 @@ impl From<AddressError> for Error {
 impl From<AddrParseError> for Error {
     fn from(err: AddrParseError) -> Error {
         ErrorKind::Config.context(err).into()
+    }
+}
+
+impl From<EncodeError> for Error {
+    fn from(err: EncodeError) -> Error {
+        ErrorKind::AllocationError.context(err).into()
     }
 }
 

--- a/steward/src/somm_send.rs
+++ b/steward/src/somm_send.rs
@@ -92,21 +92,20 @@ pub async fn data_hash(
         let msg = format!("{}:{}:{}", allocation.salt, vote_data, val_address);
         hasher.update(msg.as_bytes());
 
+        if vote.cellar.is_none() {
+            return Err(ErrorKind::AllocationError
+                .context("vote has empty cellar field")
+                .into());
+        }
+        let cellar_id = vote.cellar.clone().unwrap().id;
+
         return Ok(AllocationPrecommit {
             hash: hasher.finalize().to_vec(),
-            cellar_id: vote
-                .cellar
-                .clone()
-                .ok_or_else::<Error, _>(|| {
-                    ErrorKind::AllocationError
-                        .context("vote has empty cellar field")
-                        .into()
-                })?
-                .id,
+            cellar_id,
         });
     }
     Err(ErrorKind::AllocationError
-        .context("No cellar".to_string())
+        .context("no vote".to_string())
         .into())
 }
 

--- a/steward/src/somm_send.rs
+++ b/steward/src/somm_send.rs
@@ -60,7 +60,9 @@ async fn __send_messages(
     fee: Coin,
     messages: Vec<Msg>,
 ) -> Result<TxResponse, CosmosGrpcError> {
-    let cosmos_address = cosmos_key.to_address(&contact.get_prefix()).unwrap();
+    let cosmos_address = cosmos_key
+        .to_address(&contact.get_prefix())
+        .expect("failed to get address from cosmos key");
 
     let fee = Fee {
         amount: vec![fee],
@@ -87,14 +89,18 @@ pub async fn data_hash(
     let mut hasher = sha2::Sha256::new();
     if let Some(vote) = &allocation.clone().vote {
         let mut buf = BytesMut::new();
-        vote.encode(&mut buf).unwrap();
+        vote.encode(&mut buf)?;
         let vote_data = hex::encode(&buf);
         let msg = format!("{}:{}:{}", allocation.salt, vote_data, val_address);
         hasher.update(msg.as_bytes());
 
         return Ok(AllocationPrecommit {
             hash: hasher.finalize().to_vec(),
-            cellar_id: vote.cellar.clone().unwrap().id,
+            cellar_id: vote
+                .cellar
+                .clone()
+                .expect("vote contains no 'cellar' value")
+                .id,
         });
     }
     Err(ErrorKind::AllocationError

--- a/steward/src/somm_send.rs
+++ b/steward/src/somm_send.rs
@@ -60,9 +60,7 @@ async fn __send_messages(
     fee: Coin,
     messages: Vec<Msg>,
 ) -> Result<TxResponse, CosmosGrpcError> {
-    let cosmos_address = cosmos_key
-        .to_address(&contact.get_prefix())
-        .expect("failed to get address from cosmos key");
+    let cosmos_address = cosmos_key.to_address(&contact.get_prefix())?;
 
     let fee = Fee {
         amount: vec![fee],
@@ -99,7 +97,11 @@ pub async fn data_hash(
             cellar_id: vote
                 .cellar
                 .clone()
-                .expect("vote contains no 'cellar' value")
+                .ok_or_else::<Error, _>(||
+                    ErrorKind::AllocationError
+                        .context("vote has empty cellar field")
+                        .into(),
+                )?
                 .id,
         });
     }

--- a/steward/src/somm_send.rs
+++ b/steward/src/somm_send.rs
@@ -97,11 +97,11 @@ pub async fn data_hash(
             cellar_id: vote
                 .cellar
                 .clone()
-                .ok_or_else::<Error, _>(||
+                .ok_or_else::<Error, _>(|| {
                     ErrorKind::AllocationError
                         .context("vote has empty cellar field")
-                        .into(),
-                )?
+                        .into()
+                })?
                 .id,
         });
     }


### PR DESCRIPTION
Tried to improve error handling around some `unwrap()` calls that needed it; it seems like we lean toward using `expect()` when the failure is due to an invalid config value so I also continued that pattern. Happy to discuss.