### PR TITLE
Point CI at orchestrator main

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -12,7 +12,7 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}-steward
   HARDHAT_IMAGE: ghcr.io/peggyjv/steward-hardhat
-  ORCHESTRATOR_IMAGE_NAME: ghcr.io/peggyjv/gravity-bridge-orchestrator:latest
+  ORCHESTRATOR_IMAGE_NAME: ghcr.io/peggyjv/gravity-bridge-orchestrator:main
   SOMMELIER_IMAGE: ghcr.io/peggyjv/sommelier-sommelier:main
 
 jobs:

--- a/integration_tests/setup_test.go
+++ b/integration_tests/setup_test.go
@@ -357,6 +357,7 @@ func (s *IntegrationTestSuite) initGenesis() {
 	corkGenState.CellarIds = corktypes.CellarIDSet{
 		Ids: []string{hardhatCellar.Hex()},
 	}
+	corkGenState.Params.VotePeriod = 10
 	bz, err = cdc.MarshalJSON(&corkGenState)
 	s.Require().NoError(err)
 	appGenState[corktypes.ModuleName] = bz


### PR DESCRIPTION
Workflows have the orchestrator image defined separately from the makefile. Point at main until we have a release.