### PR TITLE
Update `gravity_bridge`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -817,6 +817,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitcoin"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a41df6ad9642c5c15ae312dd3d074de38fd3eb7cc87ad4ce10f90292a83fe4d"
+dependencies = [
+ "bech32 0.8.1",
+ "bitcoin_hashes",
+ "secp256k1 0.20.3",
+ "serde",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "006cc91e1a1d99819bc5b8214be3555c1f0611b169f527a1fdc54ed1f2b745b0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1305,7 +1326,7 @@ dependencies = [
 [[package]]
 name = "cosmos_gravity"
 version = "0.1.0"
-source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#16bf5569ec490fe333b99cc36231021a3b96a134"
+source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#4c0904073a5b87de49da0c24187150cf6b2351fe"
 dependencies = [
  "bytes 1.1.0",
  "clarity",
@@ -1476,7 +1497,7 @@ dependencies = [
 [[package]]
 name = "deep_space"
 version = "2.4.7"
-source = "git+https://github.com/iqlusioninc/deep_space/?branch=master#1f5645bf0c25cebbf6a1f81647e2ee5e4550d0ca"
+source = "git+https://github.com/iqlusioninc/deep_space/?branch=master#e35f52f5e2456a8abd26b1afe6e5cc33508c050b"
 dependencies = [
  "base64 0.13.0",
  "bech32 0.8.1",
@@ -1499,6 +1520,7 @@ dependencies = [
  "serde_json",
  "sha2 0.9.8",
  "tendermint-proto 0.21.0",
+ "tiny-keccak",
  "tokio 1.14.0",
  "tonic 0.4.3",
  "unicode-normalization",
@@ -1740,7 +1762,7 @@ dependencies = [
 [[package]]
 name = "ethereum_gravity"
 version = "0.1.0"
-source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#16bf5569ec490fe333b99cc36231021a3b96a134"
+source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#4c0904073a5b87de49da0c24187150cf6b2351fe"
 dependencies = [
  "clarity",
  "deep_space 2.4.7",
@@ -2218,8 +2240,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
  "cfg-if 1.0.0",
+ "js-sys",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2249,8 +2273,8 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "gorc"
-version = "0.3.8"
-source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#16bf5569ec490fe333b99cc36231021a3b96a134"
+version = "0.3.9"
+source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#4c0904073a5b87de49da0c24187150cf6b2351fe"
 dependencies = [
  "abscissa_core",
  "abscissa_tokio",
@@ -2289,7 +2313,7 @@ dependencies = [
 [[package]]
 name = "gravity_abi"
 version = "0.1.0"
-source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#16bf5569ec490fe333b99cc36231021a3b96a134"
+source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#4c0904073a5b87de49da0c24187150cf6b2351fe"
 dependencies = [
  "ethers",
  "serde",
@@ -2300,7 +2324,7 @@ dependencies = [
 [[package]]
 name = "gravity_abi_build"
 version = "0.1.0"
-source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#16bf5569ec490fe333b99cc36231021a3b96a134"
+source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#4c0904073a5b87de49da0c24187150cf6b2351fe"
 dependencies = [
  "ethers",
  "serde",
@@ -2311,7 +2335,7 @@ dependencies = [
 [[package]]
 name = "gravity_bridge"
 version = "0.1.0"
-source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#16bf5569ec490fe333b99cc36231021a3b96a134"
+source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#4c0904073a5b87de49da0c24187150cf6b2351fe"
 dependencies = [
  "cosmos_gravity",
  "ethereum_gravity",
@@ -2330,7 +2354,7 @@ dependencies = [
 [[package]]
 name = "gravity_proto"
 version = "0.1.0"
-source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#16bf5569ec490fe333b99cc36231021a3b96a134"
+source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#4c0904073a5b87de49da0c24187150cf6b2351fe"
 dependencies = [
  "bytes 1.1.0",
  "cosmos-sdk-proto 0.6.3",
@@ -2342,7 +2366,7 @@ dependencies = [
 [[package]]
 name = "gravity_proto_build"
 version = "0.1.0"
-source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#16bf5569ec490fe333b99cc36231021a3b96a134"
+source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#4c0904073a5b87de49da0c24187150cf6b2351fe"
 dependencies = [
  "prost 0.7.0",
  "prost-build",
@@ -2356,14 +2380,16 @@ dependencies = [
 [[package]]
 name = "gravity_utils"
 version = "0.1.0"
-source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#16bf5569ec490fe333b99cc36231021a3b96a134"
+source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#4c0904073a5b87de49da0c24187150cf6b2351fe"
 dependencies = [
+ "bitcoin",
  "clarity",
  "cosmos-sdk-proto 0.6.3",
  "deep_space 2.4.7",
  "ethers",
  "gravity_abi",
  "gravity_proto",
+ "hdpath",
  "log",
  "num-bigint 0.4.3",
  "num256",
@@ -2372,6 +2398,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha3",
+ "tiny-bip39",
  "tokio 1.14.0",
  "tonic 0.4.3",
  "url",
@@ -2455,6 +2482,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
+name = "hdpath"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72adf5a17a0952ecfcddf8d46d071271d5ee52e78443f07ba0b2dcfe3063a132"
+dependencies = [
+ "bitcoin",
+ "byteorder",
+]
+
+[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2496,6 +2533,16 @@ dependencies = [
  "rand_core 0.6.3",
  "sha2 0.9.8",
  "zeroize",
+]
+
+[[package]]
+name = "hmac"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
+dependencies = [
+ "crypto-mac 0.8.0",
+ "digest 0.9.0",
 ]
 
 [[package]]
@@ -3337,7 +3384,7 @@ dependencies = [
 [[package]]
 name = "orchestrator"
 version = "0.4.1"
-source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#16bf5569ec490fe333b99cc36231021a3b96a134"
+source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#4c0904073a5b87de49da0c24187150cf6b2351fe"
 dependencies = [
  "actix-rt 2.5.0",
  "axum",
@@ -3461,6 +3508,15 @@ name = "paste"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
+
+[[package]]
+name = "pbkdf2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216eaa586a190f0a738f2f918511eecfa90f13295abec0e457cdebcceda80cbd"
+dependencies = [
+ "crypto-mac 0.8.0",
+]
 
 [[package]]
 name = "pbkdf2"
@@ -3969,7 +4025,7 @@ checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 [[package]]
 name = "register_delegate_keys"
 version = "0.4.1"
-source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#16bf5569ec490fe333b99cc36231021a3b96a134"
+source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#4c0904073a5b87de49da0c24187150cf6b2351fe"
 dependencies = [
  "actix-rt 2.5.0",
  "clarity",
@@ -3995,7 +4051,7 @@ dependencies = [
 [[package]]
 name = "relayer"
 version = "0.4.1"
-source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#16bf5569ec490fe333b99cc36231021a3b96a134"
+source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#4c0904073a5b87de49da0c24187150cf6b2351fe"
 dependencies = [
  "actix-rt 2.5.0",
  "clarity",
@@ -4150,6 +4206,12 @@ name = "rustc-demangle"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hex"
@@ -4311,6 +4373,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d03ceae636d0fed5bae6a7f4f664354c5f4fcedf6eef053fef17e49f837d0a"
 dependencies = [
  "secp256k1-sys 0.4.1",
+ "serde",
 ]
 
 [[package]]
@@ -4928,7 +4991,7 @@ dependencies = [
 [[package]]
 name = "test_runner"
 version = "0.1.0"
-source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#16bf5569ec490fe333b99cc36231021a3b96a134"
+source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#4c0904073a5b87de49da0c24187150cf6b2351fe"
 dependencies = [
  "actix",
  "actix-rt 2.5.0",
@@ -5064,6 +5127,25 @@ dependencies = [
  "quote",
  "standback",
  "syn",
+]
+
+[[package]]
+name = "tiny-bip39"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffc59cb9dfc85bb312c3a78fd6aa8a8582e310b0fa885d5bb877f6dcc601839d"
+dependencies = [
+ "anyhow",
+ "hmac 0.8.1",
+ "once_cell",
+ "pbkdf2 0.4.0",
+ "rand 0.7.3",
+ "rustc-hash",
+ "sha2 0.9.8",
+ "thiserror",
+ "unicode-normalization",
+ "wasm-bindgen",
+ "zeroize",
 ]
 
 [[package]]

--- a/steward/src/allocation.rs
+++ b/steward/src/allocation.rs
@@ -154,7 +154,7 @@ pub async fn decide_rebalance(
             let response = somm_send::send_precommit(
                 &contact,
                 cosmos_delegate_address.to_string(),
-                cosmos_delegate_key,
+                cosmos_delegate_key.into(),
                 fee.clone(),
                 vec![allocation_precommit.to_owned()],
             )
@@ -188,7 +188,7 @@ pub async fn decide_rebalance(
             let response = somm_send::send_allocation(
                 &contact,
                 cosmos_delegate_address.to_string(),
-                cosmos_delegate_key,
+                cosmos_delegate_key.into(),
                 fee,
                 vec![allocation],
             )

--- a/steward/src/commands/tx/cosmos.rs
+++ b/steward/src/commands/tx/cosmos.rs
@@ -3,9 +3,9 @@
 use crate::{application::APP, prelude::*, utils::*};
 use abscissa_core::{clap::Parser, Command, Runnable};
 use clarity::Uint256;
-use deep_space::{coin::Coin, private_key::PrivateKey as CosmosPrivateKey};
+use deep_space::coin::Coin;
 use ethers::types::Address as EthAddress;
-use gravity_bridge::cosmos_gravity::send::send_to_eth;
+use gravity_bridge::cosmos_gravity::{crypto::PrivateKey as CosmosPrivateKey, send::send_to_eth};
 use gravity_bridge::gravity_proto::gravity::DenomToErc20Request;
 use gravity_bridge::gravity_utils::connection_prep::{check_for_fee_denom, create_rpc_connections};
 use regex::Regex;

--- a/steward/src/config.rs
+++ b/steward/src/config.rs
@@ -7,6 +7,7 @@ use crate::prelude::APP;
 use abscissa_core::Application;
 use deep_space::{Address, PrivateKey};
 use ethers::{prelude::H160, signers::LocalWallet as EthWallet};
+use gravity_bridge::cosmos_gravity;
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use signatory::FsKeyStore;
@@ -16,7 +17,7 @@ lazy_static! {
     pub static ref DELEGATE_KEY: PrivateKey = {
         let config = APP.config();
         let name = &config.keys.rebalancer_key;
-        config.load_deep_space_key(name.clone())
+        config.load_deep_space_key(name.clone()).into()
     };
     pub static ref DELEGATE_ADDRESS: Address = {
         let config = APP.config();
@@ -54,7 +55,7 @@ impl StewardConfig {
         clarity::PrivateKey::from_slice(&key).expect("Could not convert key")
     }
 
-    pub fn load_deep_space_key(&self, name: String) -> deep_space::private_key::PrivateKey {
+    pub fn load_deep_space_key(&self, name: String) -> cosmos_gravity::crypto::PrivateKey {
         let key = self.load_secret_key(name).to_bytes();
         let key = deep_space::utils::bytes_to_hex_str(&key);
         key.parse().expect("Could not parse private key")


### PR DESCRIPTION
Update the `gravity_bridge` dependency to the latest commit and fix up references to the wrapped `deep_space` Cosmos key type it now expects.