### PR TITLE
Bump automated release rust version to 1.58

### DIFF
--- a/.github/workflows/automated_release.yml
+++ b/.github/workflows/automated_release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: checkout-code
         uses: actions/checkout@v2
         with: 
-          toolchain: 1.56 
+          toolchain: 1.58
       # Rust Cache
       - name: rust-cache
         uses: actions/cache@v2


### PR DESCRIPTION
We're building with Rust 1.58 now so we need to update the release action.