### PR TITLE
Install libssl-dev before building release

### DIFF
--- a/.github/workflows/automated_release.yml
+++ b/.github/workflows/automated_release.yml
@@ -36,6 +36,9 @@ jobs:
             ~/.cargo/git/db/
             steward/target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('steward/Cargo.lock') }}
+      # Install OpenSSL dependencies
+      - name: install-packages
+        run: sudo apt-get install -y libssl-dev
       # Build Rust Artifacts
       - name: build-rust
         run: cargo install cross &&  cross build --target x86_64-unknown-linux-musl --release --all


### PR DESCRIPTION
Attempt at fixing the missing OpenSSL install issue during the release workflow.