### PR TITLE
Build release without using `cross`

### DIFF
--- a/.github/workflows/automated_release.yml
+++ b/.github/workflows/automated_release.yml
@@ -23,8 +23,6 @@ jobs:
       # Checkout repository code
       - name: checkout-code
         uses: actions/checkout@v2
-        with: 
-          toolchain: 1.58
       # Rust Cache
       - name: rust-cache
         uses: actions/cache@v2
@@ -41,7 +39,7 @@ jobs:
         run: sudo apt-get install -y libssl-dev
       # Build Rust Artifacts
       - name: build-rust
-        run: cargo install cross &&  cross build --target x86_64-unknown-linux-musl --release --all
+        run: cargo build --target x86_64-unknown-linux-musl --release --all
       # Create Release and Upload artifacts
       - name: Release
         uses: softprops/action-gh-release@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3341,9 +3341,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.38"
+version = "0.10.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
+checksum = "a61075b62a23fef5a29815de7536d940aa35ce96d18ce0cc5076272db678a577"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -3361,18 +3361,18 @@ checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-src"
-version = "300.0.2+3.0.0"
+version = "111.18.0+1.1.1n"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14a760a11390b1a5daf72074d4f6ff1a6e772534ae191f999f57e9ee8146d1fb"
+checksum = "7897a926e1e8d00219127dc020130eca4292e5ca666dd592480d72c3eca2ff6c"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.71"
+version = "0.9.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df13d165e607909b363a4757a6f133f8a818a74e9d3a98d09c6128e15fa4c73"
+checksum = "313752393519e876837e09e1fa183ddef0be7735868dced3196f4472d536277f"
 dependencies = [
  "autocfg",
  "cc",
@@ -4803,6 +4803,7 @@ dependencies = [
  "once_cell",
  "openssl",
  "openssl-probe",
+ "openssl-sys",
  "pkcs8",
  "prost 0.7.0",
  "prost-types 0.7.0",

--- a/steward/Cargo.toml
+++ b/steward/Cargo.toml
@@ -54,7 +54,8 @@ lazy_static = "1.4.0"
 # this crate. This allows for easy cross compiled builds because the 'vendored'
 # feature includes it's own OpenSSL version that's compiled on the fly
 # If ANY crate in this workspace has this it will work for all of them.
-openssl = { version = "0.10", features = ["vendored"] }
+openssl = { version = "=0.10.33", features = ["vendored"] }
+openssl-sys = "=0.9.61"
 openssl-probe = "0.1.4"
 
 


### PR DESCRIPTION
It seems like using the `cross` tool is breaking the vendoring in the way the dependency tree is structured for steward vs. gravity bridge. This version of the release action targets `x86_64-unknown-linux-musl` directly using `cargo build` and pins to the same openssl crate versions as gravity bridge.