### PR TITLE
Add the musl target via rustup

### DIFF
--- a/.github/workflows/automated_release.yml
+++ b/.github/workflows/automated_release.yml
@@ -39,7 +39,9 @@ jobs:
         run: sudo apt-get install -y libssl-dev
       # Build Rust Artifacts
       - name: build-rust
-        run: cargo build --target x86_64-unknown-linux-musl --release --all
+        run: |
+          rustup target add x86_64-unknown-linux-musl
+          cargo build --target x86_64-unknown-linux-musl --release --all
       # Create Release and Upload artifacts
       - name: Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
The rust install in the release process needs the musl target to be added.