### PR TITLE
Install musl-tools package for release

### DIFF
--- a/.github/workflows/automated_release.yml
+++ b/.github/workflows/automated_release.yml
@@ -36,7 +36,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('steward/Cargo.lock') }}
       # Install OpenSSL dependencies
       - name: install-packages
-        run: sudo apt-get install -y libssl-dev
+        run: sudo apt-get install -y libssl-dev musl-tools
       # Build Rust Artifacts
       - name: build-rust
         run: |


### PR DESCRIPTION
`musl-gcc` is necessary for building the release target, so install the right package.