### PR TITLE
Use correct path for built steward binary

### DIFF
--- a/.github/workflows/automated_release.yml
+++ b/.github/workflows/automated_release.yml
@@ -48,7 +48,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
-            steward/target/x86_64-unknown-linux-musl/release/steward
+            target/x86_64-unknown-linux-musl/release/steward
             LICENSE
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The runner directory is already "steward" so remove that from the target path.