### PR TITLE
Point to bash in gen-certs

### DIFF
--- a/gen-certs.sh
+++ b/gen-certs.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 


### PR DESCRIPTION
`/bin/sh` -> `/bin/bash` for generating certs