### PR TITLE
Make relaying opt-in

### DIFF
--- a/docs/03-TheOrchestrator.md
+++ b/docs/03-TheOrchestrator.md
@@ -7,10 +7,10 @@ The Orchestrator is a sidecar application to a Cosmos chain responsible for *orc
 The Orchestrator can be started using the following command:
 
 ```bash
-steward -c <config_toml_path> orchestrator start --orchestrator-only --ethereum-key <eth_key_name> --cosmos-key <cosmos_key_name>
+steward -c <config_toml_path> orchestrator start --ethereum-key <eth_key_name> --cosmos-key <cosmos_key_name>
 ```
 
-The `--orchestrator-only` flag prevents the Relayer thread from running, and this is the way in which we encourage validators to run the Orchestrator for now. You will burn gas on failed transactions if you run the Relayer in its current state.
+The `--relay` flag can be used to opt in to relaying Cosmos -> Ethereum transactions, which costs gas in ETH. We are only asking a couple of validators to run the relayer at this time. 
 
 The values of `--ethereum-key` and `--cosmos-key` must be the keys your validator has registered as delegate keys respectively.
 

--- a/steward/src/commands/orchestrator/start.rs
+++ b/steward/src/commands/orchestrator/start.rs
@@ -16,10 +16,10 @@ use gravity_bridge::orchestrator::main_loop::{
 use gravity_bridge::relayer::main_loop::LOOP_SPEED as RELAYER_LOOP_SPEED;
 use std::{cmp::min, sync::Arc};
 
-/// Start Orchestrator
+/// Start the Orchestrator
 #[derive(Command, Debug, Parser)]
 #[clap(
-    long_about = "DESCRIPTION \n\n Start the Orchestrator in Sommelier Chain via the Gravity Bridge.\n This command loads a Cosmos and Ethereum key with their keyname from the keystore.\n It also takes an Orchestrator_only field which when set to true, starts the Orchestrator only\n without the relayer and when set to false, starts the Orchestrator with the relayer."
+    long_about = "DESCRIPTION\n\nStarts the Gravity Bridge Orchestrator and optionally the Relayer with the --relay flag.\nYou must provide the keys delegated by your validator node for Cosmos and Ethereum signing."
 )]
 pub struct StartCommand {
     /// Cosmos keyname from keystore.
@@ -30,7 +30,7 @@ pub struct StartCommand {
     #[clap(short = 'e', long)]
     ethereum_key: String,
 
-    /// Boolean, when set to true starts the Orchestrator only and false starts Orchestrator and Relayer.
+    /// Enable Ethereum to Cosmos relaying (consumes gas in ETH)
     #[clap(short, long)]
     relay: bool,
 }

--- a/steward/src/commands/orchestrator/start.rs
+++ b/steward/src/commands/orchestrator/start.rs
@@ -32,7 +32,7 @@ pub struct StartCommand {
 
     /// Boolean, when set to true starts the Orchestrator only and false starts Orchestrator and Relayer.
     #[clap(short, long)]
-    orchestrator_only: bool,
+    relay: bool,
 }
 
 impl Runnable for StartCommand {
@@ -106,6 +106,7 @@ impl Runnable for StartCommand {
             check_for_eth(ethereum_address, eth_client.clone()).await;
 
             let gas_price = config.cosmos.gas_price.as_tuple();
+            let relayer_opt_out = !self.relay;
 
             orchestrator_main_loop(
                 cosmos_key,
@@ -118,7 +119,7 @@ impl Runnable for StartCommand {
                 config.ethereum.gas_price_multiplier,
                 config.ethereum.blocks_to_search,
                 config.cosmos.gas_adjustment,
-                self.orchestrator_only,
+                relayer_opt_out,
                 config.cosmos.msg_batch_size,
             )
             .await;

--- a/steward/src/commands/orchestrator/start.rs
+++ b/steward/src/commands/orchestrator/start.rs
@@ -106,7 +106,6 @@ impl Runnable for StartCommand {
             check_for_eth(ethereum_address, eth_client.clone()).await;
 
             let gas_price = config.cosmos.gas_price.as_tuple();
-            let relayer_opt_out = !self.relay;
 
             orchestrator_main_loop(
                 cosmos_key,
@@ -119,7 +118,7 @@ impl Runnable for StartCommand {
                 config.ethereum.gas_price_multiplier,
                 config.ethereum.blocks_to_search,
                 config.cosmos.gas_adjustment,
-                relayer_opt_out,
+                !self.relay,
                 config.cosmos.msg_batch_size,
             )
             .await;


### PR DESCRIPTION
To help prevent validators from accidentally running the relayer and potentially spending ETH for gas if their wallets are funded.

Changes the flag from `--orchestrator-only` to `--relay`