### PR TITLE
Ukpai/eth import key

### DIFF
--- a/steward/src/commands/schedule_corks/aave_cellar.rs
+++ b/steward/src/commands/schedule_corks/aave_cellar.rs
@@ -1,4 +1,8 @@
+mod fees_distributor;
 mod shutdown;
+mod sweep;
+mod transfer_ownership;
+mod trust;
 
 use abscissa_core::{clap::Parser, Command, Runnable};
 
@@ -6,4 +10,8 @@ use abscissa_core::{clap::Parser, Command, Runnable};
 #[derive(Command, Debug, Parser, Runnable)]
 pub enum AaveCellarCmd {
     Shutdown(shutdown::ShutdownCmd),
+    FeesDistributor(fees_distributor::FeesDistributorCmd),
+    Sweep(sweep::SweepCmd),
+    TransferOwnership(transfer_ownership::TransferOwnershipCmd),
+    Trust(trust::TrustCmd),
 }

--- a/steward/src/commands/schedule_corks/aave_cellar/fees_distributor.rs
+++ b/steward/src/commands/schedule_corks/aave_cellar/fees_distributor.rs
@@ -1,0 +1,9 @@
+use abscissa_core::{clap::Parser, Command, Runnable};
+
+/// Fees Distributor subcommand
+#[derive(Command, Debug, Parser)]
+pub struct FeesDistributorCmd {}
+
+impl Runnable for FeesDistributorCmd {
+    fn run(&self) {}
+}

--- a/steward/src/commands/schedule_corks/aave_cellar/sweep.rs
+++ b/steward/src/commands/schedule_corks/aave_cellar/sweep.rs
@@ -1,0 +1,10 @@
+use abscissa_core::{clap::Parser, Command, Runnable};
+
+/// Sweep subcommand
+#[derive(Command, Debug, Parser)]
+
+pub struct SweepCmd {}
+
+impl Runnable for SweepCmd {
+    fn run(&self) {}
+}

--- a/steward/src/commands/schedule_corks/aave_cellar/transfer_ownership.rs
+++ b/steward/src/commands/schedule_corks/aave_cellar/transfer_ownership.rs
@@ -1,0 +1,10 @@
+use abscissa_core::{clap::Parser, Command, Runnable};
+
+/// Transfer Ownership subcommand
+#[derive(Command, Debug, Parser)]
+
+pub struct TransferOwnershipCmd {}
+
+impl Runnable for TransferOwnershipCmd {
+    fn run(&self) {}
+}

--- a/steward/src/commands/schedule_corks/aave_cellar/trust.rs
+++ b/steward/src/commands/schedule_corks/aave_cellar/trust.rs
@@ -1,0 +1,10 @@
+use abscissa_core::{clap::Parser, Command, Runnable};
+
+/// Trust subcommand
+#[derive(Command, Debug, Parser)]
+
+pub struct TrustCmd {}
+
+impl Runnable for TrustCmd {
+    fn run(&self) {}
+}


### PR DESCRIPTION
From issue raised in the channel:

```
Gorc/steward import key commands are different in that gorc takes the key string while steward takes a mnemonic. Chorus recovers the keys to an ethereal keystore directory at startup for security purposes so they need to be able to load the key.
```