### PR TITLE
Reduce gas limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4686,7 +4686,7 @@ dependencies = [
 
 [[package]]
 name = "sommelier_steward"
-version = "1.0.1"
+version = "2.0.1"
 dependencies = [
  "lazy_static",
  "steward",
@@ -4777,7 +4777,7 @@ checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "steward"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "abscissa_core",
  "abscissa_tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sommelier_steward"
-version = "1.0.1"
+version = "2.0.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/steward/Cargo.toml
+++ b/steward/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "steward"
 authors = []
-version = "2.0.0"
+version = "2.0.1"
 edition = "2018"
 
 [dependencies]

--- a/steward/src/cork.rs
+++ b/steward/src/cork.rs
@@ -40,7 +40,7 @@ impl steward::contract_call_server::ContractCall for CorkHandler {
                 error!("cork query client connection failed: {}", err);
                 return Err(Status::new(
                     Code::Internal,
-                    "failed to query chain to validate cellar id",
+                    format!("failed to query chain to validate cellar id: {}", err),
                 ));
             }
         };
@@ -84,7 +84,7 @@ impl steward::contract_call_server::ContractCall for CorkHandler {
                 format!("failed to send cork to sommelier: {}", err),
             ));
         }
-        info!("submitted cork for {}!", cellar_id);
+        info!("submitted cork for {}", cellar_id);
 
         Ok(Response::new(SubmitResponse {}))
     }

--- a/steward/src/cork.rs
+++ b/steward/src/cork.rs
@@ -81,7 +81,7 @@ impl steward::contract_call_server::ContractCall for CorkHandler {
             error!("failed to submit cork: {}", err);
             return Err(Status::new(
                 Code::Internal,
-                "failed to send cork to sommelier",
+                format!("failed to send cork to sommelier: {}", err),
             ));
         }
         info!("submitted cork for {}!", cellar_id);

--- a/steward/src/somm_send.rs
+++ b/steward/src/somm_send.rs
@@ -56,7 +56,7 @@ async fn __send_messages(
 
     let fee = Fee {
         amount: vec![fee],
-        gas_limit: 500_000_000u64 * (messages.len() as u64),
+        gas_limit: 500_000u64 * (messages.len() as u64),
         granter: None,
         payer: None,
     };


### PR DESCRIPTION
Having a really large gas limit like `500_000_000` was causing issues with transaction submission on mainnet for mysterious reasons. This lowers it to `500_000` and bumps the steward version to 2.0.1.