### PR TITLE
Update relayer to use gas_multiplier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1326,7 +1326,7 @@ dependencies = [
 [[package]]
 name = "cosmos_gravity"
 version = "0.1.0"
-source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#4e1b44e46dbdac342f19655dcc9d54dafeec4a35"
+source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#2e364260a6bf9c55bbff264f27016b2d53272f4a"
 dependencies = [
  "bytes 1.1.0",
  "clarity",
@@ -1762,7 +1762,7 @@ dependencies = [
 [[package]]
 name = "ethereum_gravity"
 version = "0.1.0"
-source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#4e1b44e46dbdac342f19655dcc9d54dafeec4a35"
+source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#2e364260a6bf9c55bbff264f27016b2d53272f4a"
 dependencies = [
  "clarity",
  "deep_space 2.4.7",
@@ -2274,7 +2274,7 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 [[package]]
 name = "gorc"
 version = "2.0.1"
-source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#4e1b44e46dbdac342f19655dcc9d54dafeec4a35"
+source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#2e364260a6bf9c55bbff264f27016b2d53272f4a"
 dependencies = [
  "abscissa_core",
  "abscissa_tokio",
@@ -2313,7 +2313,7 @@ dependencies = [
 [[package]]
 name = "gravity_abi"
 version = "0.1.0"
-source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#4e1b44e46dbdac342f19655dcc9d54dafeec4a35"
+source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#2e364260a6bf9c55bbff264f27016b2d53272f4a"
 dependencies = [
  "ethers",
  "serde",
@@ -2324,7 +2324,7 @@ dependencies = [
 [[package]]
 name = "gravity_abi_build"
 version = "0.1.0"
-source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#4e1b44e46dbdac342f19655dcc9d54dafeec4a35"
+source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#2e364260a6bf9c55bbff264f27016b2d53272f4a"
 dependencies = [
  "ethers",
  "serde",
@@ -2335,7 +2335,7 @@ dependencies = [
 [[package]]
 name = "gravity_bridge"
 version = "0.1.0"
-source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#4e1b44e46dbdac342f19655dcc9d54dafeec4a35"
+source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#2e364260a6bf9c55bbff264f27016b2d53272f4a"
 dependencies = [
  "cosmos_gravity",
  "ethereum_gravity",
@@ -2354,7 +2354,7 @@ dependencies = [
 [[package]]
 name = "gravity_proto"
 version = "0.1.0"
-source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#4e1b44e46dbdac342f19655dcc9d54dafeec4a35"
+source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#2e364260a6bf9c55bbff264f27016b2d53272f4a"
 dependencies = [
  "bytes 1.1.0",
  "cosmos-sdk-proto 0.6.3",
@@ -2366,7 +2366,7 @@ dependencies = [
 [[package]]
 name = "gravity_proto_build"
 version = "0.1.0"
-source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#4e1b44e46dbdac342f19655dcc9d54dafeec4a35"
+source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#2e364260a6bf9c55bbff264f27016b2d53272f4a"
 dependencies = [
  "prost 0.7.0",
  "prost-build",
@@ -2380,7 +2380,7 @@ dependencies = [
 [[package]]
 name = "gravity_utils"
 version = "0.1.0"
-source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#4e1b44e46dbdac342f19655dcc9d54dafeec4a35"
+source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#2e364260a6bf9c55bbff264f27016b2d53272f4a"
 dependencies = [
  "bitcoin",
  "clarity",
@@ -3385,7 +3385,7 @@ dependencies = [
 [[package]]
 name = "orchestrator"
 version = "2.0.1"
-source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#4e1b44e46dbdac342f19655dcc9d54dafeec4a35"
+source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#2e364260a6bf9c55bbff264f27016b2d53272f4a"
 dependencies = [
  "actix-rt 2.5.0",
  "axum",
@@ -4026,7 +4026,7 @@ checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 [[package]]
 name = "register_delegate_keys"
 version = "2.0.0"
-source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#4e1b44e46dbdac342f19655dcc9d54dafeec4a35"
+source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#2e364260a6bf9c55bbff264f27016b2d53272f4a"
 dependencies = [
  "actix-rt 2.5.0",
  "clarity",
@@ -4052,7 +4052,7 @@ dependencies = [
 [[package]]
 name = "relayer"
 version = "2.0.0"
-source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#4e1b44e46dbdac342f19655dcc9d54dafeec4a35"
+source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#2e364260a6bf9c55bbff264f27016b2d53272f4a"
 dependencies = [
  "actix-rt 2.5.0",
  "clarity",
@@ -4992,7 +4992,7 @@ dependencies = [
 [[package]]
 name = "test_runner"
 version = "0.1.0"
-source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#4e1b44e46dbdac342f19655dcc9d54dafeec4a35"
+source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#2e364260a6bf9c55bbff264f27016b2d53272f4a"
 dependencies = [
  "actix",
  "actix-rt 2.5.0",

--- a/docs/01-Configuration.md
+++ b/docs/01-Configuration.md
@@ -144,6 +144,17 @@ Multiplied by estimated gas fee per transaction. If your Ethereum transactions a
 gas_price_multiplier = 1.0
 ```
 
+#### `gas_multiplier`
+
+Type: float
+
+Multiplied by estimated gas limit per transaction. If your Ethereum transactions are failing due to insufficient gas, try increasing this value.
+
+```
+[ethereum]
+gas_multiplier = 1.0
+```
+
 #### `key_derivation_path`
 
 Type: string
@@ -305,6 +316,7 @@ denom = "usomm"
 [ethereum]
 blocks_to_search = 5000
 gas_price_multiplier = 1.0
+gas_multiplier = 1.1
 key_derivation_path = "m/44'/60'/0'/0/0"
 rpc = "http://localhost:8545"
 

--- a/steward/src/commands/orchestrator/start.rs
+++ b/steward/src/commands/orchestrator/start.rs
@@ -116,6 +116,7 @@ impl Runnable for StartCommand {
                 gas_price,
                 &config.metrics.listen_addr,
                 config.ethereum.gas_price_multiplier,
+                config.ethereum.gas_multiplier,
                 config.ethereum.blocks_to_search,
                 config.cosmos.gas_adjustment,
                 self.orchestrator_only,

--- a/steward/src/config.rs
+++ b/steward/src/config.rs
@@ -130,6 +130,7 @@ impl Default for KeysConfig {
 pub struct EthereumSection {
     pub blocks_to_search: u64,
     pub gas_price_multiplier: f32,
+    pub gas_multiplier: f32,
     pub key_derivation_path: String,
     pub rpc: String,
 }
@@ -139,6 +140,7 @@ impl Default for EthereumSection {
         Self {
             blocks_to_search: 5000,
             gas_price_multiplier: 1.0f32,
+            gas_multiplier: 1.0f32,
             key_derivation_path: "m/44'/60'/0'/0/0".to_owned(),
             rpc: "http://localhost:8545".to_owned(),
         }


### PR DESCRIPTION
`cargo update` for `gravity_bridge` and put `gas_multiplier` into the Ethereum config to pass onto the orchestrator start command.