### PR TITLE
Excluding steward_abi directory from cargo clippy

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -73,11 +73,11 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-          paths-ignore: |
-            steward_abi/**
-            steward_proto_rust/**
       - run: rustup component add clippy
       - uses: actions-rs/cargo@v1
         with:
+          paths-ignore: |
+            steward_abi/**
+            steward_proto_rust/**
           command: clippy
           args: -- -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -82,4 +82,4 @@ jobs:
             steward_abi/**
             steward_proto_rust/src/prost/steward.v2.rs
           command: clippy
-          args: -- -D warnings
+          args: -- -D warnings --no-deps

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -82,4 +82,4 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
       - name: Run Cargo build
-        run: cargo clippy --no-deps -- -D warnings
+        run: cargo clippy -p steward -- -D warnings --no-deps

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -76,8 +76,8 @@ jobs:
       - run: rustup component add clippy
       - uses: actions-rs/cargo@v1
         with:
-          path: |
-            !steward_abi/**
-            !steward_proto_rust/**
+          paths-ignore: |
+            steward_abi/**
+            steward_proto_rust/src/prost/steward.v2.rs
           command: clippy
           args: -- -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,20 +66,20 @@ jobs:
           command: fmt
           args: --all -- --check
   clippy:
-    name: Clippy
     runs-on: ubuntu-latest
     steps:
       - name: Checkout branch
         uses: actions/checkout@v2
+      - name: Set up Rust caches
+        uses: actions/cache@v2
+        id: rust-cache
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - run: rustup component add clippy
-      - uses: actions-rs/cargo@v1
-        with:
-          paths-ignore: |
-            steward_abi/**
-            steward_proto_rust/src/prost/steward.v2.rs
-          command: clippy
-          args: --no-deps -- -D warnings
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+      - name: Run Cargo build
+        run: cargo clippy --no-deps -- -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -78,6 +78,6 @@ jobs:
         with:
           paths-ignore: |
             steward_abi/**
-            steward_proto_rust/**
+            steward_proto_rust/
           command: clippy
           args: -- -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -79,4 +79,4 @@ jobs:
             !steward_proto_rust/
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
       - name: Run Cargo build
-        run: cargo build
+        run: cargo clippy -- -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -82,4 +82,4 @@ jobs:
             steward_abi/**
             steward_proto_rust/src/prost/steward.v2.rs
           command: clippy
-          args: -- -D warnings --no-deps
+          args: --no-deps -- -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -75,6 +75,7 @@ jobs:
           override: true
           paths-ignore: |
             steward_abi/**
+            steward_proto_rust/**
       - run: rustup component add clippy
       - uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,8 +5,7 @@ on:
     branches:
       - main
   pull_request:
-    paths-ignore:
-      - steward_proto_rust_build/**
+    
 
 env:
   CARGO_TERM_COLOR: always
@@ -74,6 +73,8 @@ jobs:
         uses: actions/cache@v2
         id: rust-cache
         with:
+          paths-ignore: |
+             steward_proto_rust_build/**
           path: |
             ~/.cargo/bin/
             ~/.cargo/registry/index/
@@ -82,4 +83,4 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
       - name: Run Cargo build
-        run: cargo clippy -p steward -- -D warnings --no-deps
+        run: cargo clippy -- -D warnings --no-deps

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,11 +2,11 @@ name: Rust tests
 
 on:
   push:
-    paths-ignore:
-      - 'docs/**'
     branches:
       - main
   pull_request:
+    paths-ignore:
+      - steward_proto_rust_build/**
 
 env:
   CARGO_TERM_COLOR: always
@@ -71,12 +71,15 @@ jobs:
     steps:
       - name: Checkout branch
         uses: actions/checkout@v2
-      - name: Set up Rust caches
-        uses: actions/cache@v2
-        id: rust-cache
         with:
-          path: |
-            !steward_proto_rust/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
-      - name: Run Cargo build
-        run: cargo clippy -- -D warnings
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: rustup component add clippy
+      - uses: actions-rs/cargo@v1
+        with:
+          paths-ignore: |
+            steward_abi/**
+            steward_proto_rust/src/prost/steward.v2.rs
+          command: clippy
+          args: -- -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,7 +28,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
       - name: Run Cellar_Rebalancer acceptance tests
         run: cargo test --all --verbose
-  
+
   rust-build:
     runs-on: ubuntu-latest
     steps:
@@ -47,11 +47,11 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
       - name: Run Cargo build
         run: cargo build
-  
+
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest
-    steps:       
+    steps:
       - name: Checkout branch
         uses: actions/checkout@v2
         with:
@@ -66,13 +66,15 @@ jobs:
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
-    steps:  
+    steps:
       - name: Checkout branch
         uses: actions/checkout@v2
         with:
           profile: minimal
           toolchain: stable
           override: true
+          paths-ignore: |
+            steward_abi/**
       - run: rustup component add clippy
       - uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,6 +2,9 @@ name: Rust tests
 
 on:
   push:
+    paths-ignore:
+      - steward_abi/**
+      - steward_proto_rust/**
     branches:
       - main
   pull_request:
@@ -26,7 +29,7 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
-      - name: Run Cellar_Rebalancer acceptance tests
+      - name: Run Steward acceptance tests
         run: cargo test --all --verbose
 
   rust-build:
@@ -78,6 +81,6 @@ jobs:
         with:
           paths-ignore: |
             steward_abi/**
-            steward_proto_rust/src/prost/steward.v2.rs
+            steward_proto_rust/**
           command: clippy
           args: -- -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -76,8 +76,8 @@ jobs:
       - run: rustup component add clippy
       - uses: actions-rs/cargo@v1
         with:
-          paths-ignore: |
-            steward_abi/**
-            steward_proto_rust/
+          path: |
+            !steward_abi/**
+            !steward_proto_rust/**
           command: clippy
           args: -- -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,8 +3,7 @@ name: Rust tests
 on:
   push:
     paths-ignore:
-      - steward_abi/**
-      - steward_proto_rust/**
+      - 'docs/**'
     branches:
       - main
   pull_request:
@@ -72,15 +71,12 @@ jobs:
     steps:
       - name: Checkout branch
         uses: actions/checkout@v2
+      - name: Set up Rust caches
+        uses: actions/cache@v2
+        id: rust-cache
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - run: rustup component add clippy
-      - uses: actions-rs/cargo@v1
-        with:
-          paths-ignore: |
-            steward_abi/**
-            steward_proto_rust/**
-          command: clippy
-          args: -- -D warnings
+          path: |
+            !steward_proto_rust/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+      - name: Run Cargo build
+        run: cargo build


### PR DESCRIPTION
This will exclude Rust automatically generated files from cargo clips, because it keeps failing and throwing warnings.