### PR TITLE
Clarify test certificates must be removed after testing

### DIFF
--- a/docs/04-GeneratingCertificates.md
+++ b/docs/04-GeneratingCertificates.md
@@ -44,7 +44,7 @@ Valid TLS certificates will have "Version 3" near the top of the certificate pla
 
 6. Test Steward with your certificate
 
-A temporary test client CA can be used verify your steward process is connectable from the network.  The test client CA MUST BE REMOVED prior to running in production.
+A temporary test client CA can be used to verify your steward process is connectable from the network.  The test client CA MUST BE REMOVED prior to running in production.
 
 The test client CA is included in this repo at:
 ```

--- a/docs/04-GeneratingCertificates.md
+++ b/docs/04-GeneratingCertificates.md
@@ -44,9 +44,9 @@ Valid TLS certificates will have "Version 3" near the top of the certificate pla
 
 6. Test Steward with your certificate
 
-A temporary test client certificate can be used verify your steward process is connectable from the network.  The test certificate MUST BE REMOVED prior to running in production.
+A temporary test client CA can be used verify your steward process is connectable from the network.  The test client CA MUST BE REMOVED prior to running in production.
 
-The test certificate is included in this repo at:
+The test client CA is included in this repo at:
 ```
 integration_tests/tls/client/test_client_ca.crt
 ```

--- a/docs/04-GeneratingCertificates.md
+++ b/docs/04-GeneratingCertificates.md
@@ -44,7 +44,14 @@ Valid TLS certificates will have "Version 3" near the top of the certificate pla
 
 6. Test Steward with your certificate
 
-You can use the test client certificates included in this repo to simulate a client connection to Steward. You'll need to create a TOML config file with the `[server]` section containing the paths to your generated artifacts. See the configuration reference for more info. Your file will need to look something like this:
+A temporary test client certificate can be used verify your steward process is connectable from the network.  The test certificate MUST BE REMOVED prior to running in production.
+
+The test certificate is included in this repo at:
+```
+integration_tests/tls/client/test_client_ca.crt
+```
+
+Create a TOML config file with the `[server]` section containing the paths to your generated artifacts. See the configuration reference for more info. Your file will need to look something like this:
 
 ```toml
 [server]
@@ -80,10 +87,31 @@ grpcurl -cert integration_tests/tls/client/test_client.crt \
 	-cacert <output_path>/server_ca.crt \
 	-d '' \
 	<fqdn_of_server>:5734 \
-	steward.v1.ContractCall/Submit
+	steward.v2.ContractCall/Submit
 ```
 
-When you send this request, if you get an error to establishing a connection, there is probably something wrong with your configuration or your certificates. If you get an error internal to the business logic of Steward, you know it's working.
+If you see a response like the following, then your process is accepting connections properly.
+```
+Resolved method descriptor:
+// Handles simple contract call submission
+rpc Submit ( .steward.v2.SubmitRequest ) returns ( .steward.v2.SubmitResponse );
+
+Request metadata to send:
+(empty)
+
+Response headers received:
+(empty)
+
+Response trailers received:
+content-type: application/grpc
+date: Mon, 03 Oct 2022 19:00:02 GMT
+Sent 0 requests and received 0 responses
+ERROR:
+  Code: PermissionDenied
+  Message: cellar ID  not approved by governance
+```
+
+When you send this request, if you get an error to establishing a connection, there is probably something wrong with your configuration or your certificates. 
 
 An error like this one means the connection was established successfully:
 
@@ -99,7 +127,15 @@ ERROR:
   Message: failed to query chain to validate cellar id
 ```
 
-7. Provide your CA to the Strategy Provider
+7. Remove testing configuration
+
+In Production, steward must run without the client_ca_cert_path set.  If you edited your production TOML file for testing, remove the client_ca_cert_path value from the [server] section.
+
+```toml
+client_ca_cert_path = "..." # remove this temporary line
+```
+
+8. Provide your CA to the Strategy Provider
 
 Add your information to the [Steward Registry](https://github.com/peggyjv/steward-registry) by following the steps outlined in the README there.
 


### PR DESCRIPTION
Strictly following the previous instructions in sequence would leave the test client CA installed.

Edits make clear that test certificates must be removed.