### PR TITLE
Compare binary and release versions on release

### DIFF
--- a/.github/workflows/automated_release.yml
+++ b/.github/workflows/automated_release.yml
@@ -23,6 +23,8 @@ jobs:
       # Checkout repository code
       - name: checkout-code
         uses: actions/checkout@v2
+      - name: "Check version"
+        run: ./check_version.sh
       # Rust Cache
       - name: rust-cache
         uses: actions/cache@v2

--- a/check_version.sh
+++ b/check_version.sh
@@ -4,7 +4,7 @@ set -e
 
 # this is a little fragile because it assumes the [package] section will be at the
 # top of the Cargo.toml
-BINARY_VERSION_STRING=$(cat steward/Cargo.toml | grep "^(version = \")([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?" | head -1)
+BINARY_VERSION_STRING=$(cat steward/Cargo.toml | grep "^\(version = \"\)\([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\)\(?:-\([0-9A-Za-z-]\+\(?:\.[0-9A-Za-z-]\+\)*\)\)\?\(?:\+[0-9A-Za-z-]\+\)\?" | head -1)
 # above output is 'version = "x.x.x"' so we trim the leading and trailing characters
 BINARY_VERSION=${BINARY_VERSION_STRING:11:-1}
 # trim the leading 'v' from the tag

--- a/check_version.sh
+++ b/check_version.sh
@@ -4,7 +4,7 @@ set -e
 
 # this is a little fragile because it assumes the [package] section will be at the
 # top of the Cargo.toml
-BINARY_VERSION_STRING=$(cat steward/Cargo.toml | grep "^version.*" | head -1)
+BINARY_VERSION_STRING=$(cat steward/Cargo.toml | grep "^(version = \")([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?" | head -1)
 # above output is 'version = "x.x.x"' so we trim the leading and trailing characters
 BINARY_VERSION=${BINARY_VERSION_STRING:11:-1}
 # trim the leading 'v' from the tag

--- a/check_version.sh
+++ b/check_version.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+# this is a little fragile because it assumes the [package] section will be at the
+# top of the Cargo.toml
+BINARY_VERSION_STRING=$(cat steward/Cargo.toml | grep "^version.*" | head -1)
+# above output is 'version = "x.x.x"' so we trim the leading and trailing characters
+BINARY_VERSION=${BINARY_VERSION_STRING:11:-1}
+# trim the leading 'v' from the tag
+RELEASE_VERSION=${GITHUB_REF_NAME: 1}
+
+echo "Release version: $RELEASE_VERSION"
+echo "Binary version: $BINARY_VERSION"
+
+if [ "$RELEASE_VERSION" != "$BINARY_VERSION" ]; then
+    >&2 echo "Version mismatch. Has the binary version been bumped?"
+    exit 1
+fi


### PR DESCRIPTION
A naive version check, comparing the `Cargo.toml` package version with the release tag to prevent releasing a binary with a version mismatch. It's a little brittle as the `grep` command used assume the `[package]` section is at the top of the TOML and thus will be the first match of "^version = ...". My bash-fu is weak, so please recommend a more reliable command if needed.

If/when this is merged I'll do the same for the orchestrator. 