### PR TITLE
Edit cosmos gas_adjustment value recommendation

### DIFF
--- a/docs/01-Configuration.md
+++ b/docs/01-Configuration.md
@@ -39,11 +39,11 @@ Configuration related interactions with the Cosmos chain in question
 
 Type: float
 
-Multiplied by estimated gas fee per transaction. Currently Sommelier fee requirements are 0.0 so this can be left as default.
+Multiplied by estimated gas fee per transaction. It is recommended to set this to a value above 1.0 to avoid gas estimation issues.
 
 ```
 [cosmos]
-gas_adjustment = 1.0
+gas_adjustment = 1.1
 ```
 
 #### `grpc`
@@ -302,7 +302,7 @@ This example will not work as is, you'll need to supply your own values.
 keystore = "/some/path/keystore"
 
 [cosmos]
-gas_adjustment = 1.0
+gas_adjustment = 1.1
 grpc = "https://127.0.0.1:9090"
 key_derivation_path = "m/44'/118'/0'/0/0"
 prefix = "somm"

--- a/steward/src/config.rs
+++ b/steward/src/config.rs
@@ -177,7 +177,7 @@ pub struct CosmosSection {
 impl Default for CosmosSection {
     fn default() -> Self {
         Self {
-            gas_adjustment: 1.0f64,
+            gas_adjustment: 1.1f64,
             grpc: "https://127.0.0.1:9090".to_owned(),
             key_derivation_path: "m/44'/118'/0'/0/0".to_owned(),
             prefix: "somm".to_owned(),


### PR DESCRIPTION
Edit cosmos gas_adjustment value recommendation. Some orchestrators are failing to submit ethereum events because their adjustment is set to 1.0 and `gasWanted` is set just under `gasRequired` in their tx. 