### PR TITLE
Improve CI performance by fixing build caching

### DIFF
--- a/.github/workflows/automated_release.yml
+++ b/.github/workflows/automated_release.yml
@@ -27,15 +27,14 @@ jobs:
         run: ./check_version.sh
       # Rust Cache
       - name: rust-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
+        id: rust-cache
         with:
           path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            steward/target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('steward/Cargo.lock') }}
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       # Install OpenSSL dependencies
       - name: install-packages
         run: sudo apt-get install -y libssl-dev musl-tools

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,7 +10,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  rust-test:
+  rust-build-test:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout branch
@@ -20,33 +20,14 @@ jobs:
         id: rust-cache
         with:
           path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
-      - name: Run steward acceptance tests
-        run: cargo test --all --verbose
-
-  rust-build:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout branch
-        uses: actions/checkout@v2
-      - name: Set up Rust caches
-        uses: actions/cache@v2
-        id: rust-cache
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
       - name: Run Cargo build
         run: cargo build
+      - name: Run steward acceptance tests
+        run: cargo test --all --verbose
 
   fmt:
     name: Rustfmt

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,5 +1,5 @@
 name: Rust tests
-
+# test
 on:
   push:
     branches:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,5 +1,4 @@
 name: Rust tests
-# test
 on:
   push:
     branches:
@@ -16,14 +15,14 @@ jobs:
       - name: Checkout branch
         uses: actions/checkout@v2
       - name: Set up Rust caches
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: rust-cache
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Run Cargo build
         run: cargo build
       - name: Run steward acceptance tests
@@ -54,6 +53,15 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+      - name: Restore Cargo cache
+        uses: actions/cache/restore@v3
+        id: rust-cache
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Add clippy
         run: rustup component add clippy
       - name: Run clippy

--- a/steward/src/cellars/cellar_v1.rs
+++ b/steward/src/cellars/cellar_v1.rs
@@ -29,6 +29,7 @@ use super::{log_cellar_call, log_governance_cellar_call};
 const CELLAR_NAME: &str = "CellarV1";
 const LOG_PREFIX: &str = CELLAR_NAME;
 
+// rust change
 pub fn get_encoded_call(function: StrategyFunction, cellar_id: String) -> Result<Vec<u8>, Error> {
     match function {
         AddPosition(params) => {

--- a/steward/src/cellars/cellar_v1.rs
+++ b/steward/src/cellars/cellar_v1.rs
@@ -29,7 +29,7 @@ use super::{log_cellar_call, log_governance_cellar_call};
 const CELLAR_NAME: &str = "CellarV1";
 const LOG_PREFIX: &str = CELLAR_NAME;
 
-// rust change
+
 pub fn get_encoded_call(function: StrategyFunction, cellar_id: String) -> Result<Vec<u8>, Error> {
     match function {
         AddPosition(params) => {

--- a/steward/src/cellars/cellar_v1.rs
+++ b/steward/src/cellars/cellar_v1.rs
@@ -29,7 +29,6 @@ use super::{log_cellar_call, log_governance_cellar_call};
 const CELLAR_NAME: &str = "CellarV1";
 const LOG_PREFIX: &str = CELLAR_NAME;
 
-
 pub fn get_encoded_call(function: StrategyFunction, cellar_id: String) -> Result<Vec<u8>, Error> {
     match function {
         AddPosition(params) => {


### PR DESCRIPTION
Maybe hold off on merging this until after 3.x Cellar V2 stuff?

Fix CI build caching. Rust build time changes from ~10m to ~1.5m, longer for builds with dependency changes.

Please squash before merging.