### PR TITLE
On an error querying a proposal just log the error and continue rathe…

### DIFF
--- a/src/proposals.rs
+++ b/src/proposals.rs
@@ -191,9 +191,15 @@ async fn poll_approved_proposals(
 
                         break;
                     }
-                } else {
+                } else if err.code() == Code::Unknown {
                     error!("error querying proposal {}: {}", proposal_id, err);
+
                     continue;
+                } else {
+                    return Err(proposal_processing_error(format!(
+                        "error querying proposal {}: {}",
+                        proposal_id, err
+                    )));
                 }
             }
         };

--- a/src/proposals.rs
+++ b/src/proposals.rs
@@ -192,10 +192,8 @@ async fn poll_approved_proposals(
                         break;
                     }
                 } else {
-                    return Err(proposal_processing_error(format!(
-                        "error querying proposal {}: {}",
-                        proposal_id, err
-                    )));
+                    error!("error querying proposal {}: {}", proposal_id, err);
+                    continue;
                 }
             }
         };

--- a/src/proposals.rs
+++ b/src/proposals.rs
@@ -194,6 +194,8 @@ async fn poll_approved_proposals(
                 } else if err.code() == Code::Unknown {
                     error!("error querying proposal {}: {}", proposal_id, err);
 
+                    state.last_finalized_proposal_id = proposal_id;
+
                     continue;
                 } else {
                     return Err(proposal_processing_error(format!(


### PR DESCRIPTION
…r than

aborting and stoping

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Improved error handling in the proposal polling process, allowing the system to continue processing other proposals even when an error occurs.
  
- **Bug Fixes**
	- Resolved issues related to premature termination of the proposal polling due to individual query failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->