### PR TITLE
chore: Fix linter issues by bumping abscissa and clap dependencies

### DIFF
--- a/.github/workflows/automated_release.yml
+++ b/.github/workflows/automated_release.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   release:
     name: build-release-assets
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       # Setup Rust Environment
       - name: setup-rust

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -24,7 +24,7 @@ jobs:
     permissions:
       contents: write
       packages: write
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: checkout
         uses: actions/checkout@v2
@@ -72,7 +72,7 @@ jobs:
     permissions:
       contents: write
       packages: write
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: checkout
         uses: actions/checkout@v2
@@ -120,7 +120,7 @@ jobs:
       contents: write
       packages: write
     environment: CI
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [ steward-build, hardhat-build ]
     strategy:
       fail-fast: false

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -58,7 +58,7 @@ jobs:
           cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
           outputs: type=docker,dest=${{ env.UPLOAD_DIR }}/${{ env.HARDHAT_ARTIFACT }}
       - name: Make hardhat image artifact available to other jobs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.HARDHAT_IMAGE_NAME }}
           path: ${{ env.UPLOAD_DIR }}/${{ env.HARDHAT_ARTIFACT }}
@@ -105,7 +105,7 @@ jobs:
           cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
           outputs: type=docker,dest=${{ env.UPLOAD_DIR }}/${{ env.STEWARD_ARTIFACT }}
       - name: Make Steward artifact available to other jobs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.IMAGE_NAME }}
           path: ${{ env.UPLOAD_DIR }}/${{ env.STEWARD_ARTIFACT }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: docker-cache
         with:
           path: /tmp/.buildx-cache
@@ -79,7 +79,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: docker-cache
         with:
           path: /tmp/.buildx-cache
@@ -134,7 +134,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
       - name: go-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cache/go-build

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -168,7 +168,7 @@ jobs:
       - name: Make download dir
         run: mkdir -p ${{ env.DOWNLOAD_DIR }}
       - name: Get hardhat artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.HARDHAT_IMAGE_NAME }}
           path: ${{ env.DOWNLOAD_DIR }}/
@@ -177,7 +177,7 @@ jobs:
       - name: Rename hardhat image
         run: docker tag ${{ steps.meta-hardhat.outputs.tags }} ethereum:prebuilt
       - name: Get steward artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.IMAGE_NAME }}
           path: ${{ env.DOWNLOAD_DIR }}/

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   rust-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout branch
         uses: actions/checkout@v3
@@ -30,7 +30,7 @@ jobs:
         run: cargo test --all --verbose
 
   rust-build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout branch
         uses: actions/checkout@v3
@@ -50,7 +50,7 @@ jobs:
 
   fmt:
     name: Rustfmt
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout branch
         uses: actions/checkout@v3
@@ -61,7 +61,7 @@ jobs:
 
   clippy:
     name: Clippy
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout branch
         uses: actions/checkout@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout branch
         uses: actions/checkout@v3
       - name: Set up Rust caches
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: rust-cache
         with:
           path: |
@@ -35,7 +35,7 @@ jobs:
       - name: Checkout branch
         uses: actions/checkout@v3
       - name: Set up Rust caches
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: rust-cache
         with:
           path: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4045,7 +4045,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "steward"
-version = "4.2.6"
+version = "4.2.7"
 dependencies = [
  "abscissa_core",
  "abscissa_tokio",
@@ -4106,7 +4106,7 @@ dependencies = [
 
 [[package]]
 name = "steward-proto"
-version = "4.2.6"
+version = "4.2.7"
 dependencies = [
  "prost",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2818,40 +2818,51 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.33"
+version = "0.10.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a61075b62a23fef5a29815de7536d940aa35ce96d18ce0cc5076272db678a577"
+checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.2",
  "cfg-if",
  "foreign-types",
  "libc",
  "once_cell",
+ "openssl-macros",
  "openssl-sys",
 ]
 
 [[package]]
-name = "openssl-probe"
-version = "0.1.5"
+name = "openssl-macros"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-src"
-version = "111.28.1+1.1.1w"
+version = "300.4.2+3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bf7e82ffd6d3d6e6524216a0bfd85509f68b5b28354e8e7800057e44cefa9b4"
+checksum = "168ce4e058f975fe43e89d9ccf78ca668601887ae736090aacc23ae353c298e2"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.61"
+version = "0.9.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "313752393519e876837e09e1fa183ddef0be7735868dced3196f4472d536277f"
+checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
 dependencies = [
- "autocfg",
  "cc",
  "libc",
  "openssl-src",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,22 +18,48 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6750843603bf31a83accd3c8177f9dbf53a7d64275688fc7371e0a4d9f8628b5"
 dependencies = [
- "abscissa_derive",
+ "abscissa_derive 0.6.0",
  "arc-swap",
  "backtrace",
  "canonical-path",
- "clap",
+ "clap 3.2.25",
  "color-eyre",
  "fs-err",
  "once_cell",
  "regex",
- "secrecy",
+ "secrecy 0.8.0",
  "semver",
  "serde",
  "termcolor",
- "toml",
+ "toml 0.5.11",
  "tracing",
  "tracing-log 0.1.4",
+ "tracing-subscriber",
+ "wait-timeout",
+]
+
+[[package]]
+name = "abscissa_core"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3083187ad864402d6bde86c5b51767b921edf4d02bf03b8ba40172dbd2a9773b"
+dependencies = [
+ "abscissa_derive 0.8.2",
+ "arc-swap",
+ "backtrace",
+ "canonical-path",
+ "clap 4.5.32",
+ "color-eyre",
+ "fs-err",
+ "once_cell",
+ "regex",
+ "secrecy 0.10.3",
+ "semver",
+ "serde",
+ "termcolor",
+ "toml 0.8.12",
+ "tracing",
+ "tracing-log 0.2.0",
  "tracing-subscriber",
  "wait-timeout",
 ]
@@ -52,12 +78,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "abscissa_derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d914621d2ef4da433fe01907e323ee3f2807738d392d5a34c287b381f87fe2"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "synstructure",
+]
+
+[[package]]
 name = "abscissa_tokio"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32ce48eff491a0ab32c0e1cadd7ba5221a38dc53438992c5e857ab9b8a3f1a3e"
 dependencies = [
- "abscissa_core",
+ "abscissa_core 0.6.0",
+ "actix-rt",
+ "tokio",
+]
+
+[[package]]
+name = "abscissa_tokio"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbfe75534601ac38dd9119c552c97b91814b079c065efdbfcabd7a1eb998c23e"
+dependencies = [
+ "abscissa_core 0.8.2",
  "actix-rt",
  "tokio",
 ]
@@ -162,6 +212,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "550632e31568ae1a5f47998c3aa48563030fc49b9ec91913ca337cf64fbc5ccb"
 dependencies = [
  "backtrace",
+]
+
+[[package]]
+name = "anstream"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -738,13 +837,35 @@ checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "atty",
  "bitflags 1.3.2",
- "clap_derive",
- "clap_lex",
+ "clap_derive 3.2.25",
+ "clap_lex 0.2.4",
  "indexmap 1.9.3",
  "once_cell",
- "strsim",
+ "strsim 0.10.0",
  "termcolor",
  "textwrap",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6088f3ae8c3608d19260cd7445411865a485688711b78b5be70d78cd96136f83"
+dependencies = [
+ "clap_builder",
+ "clap_derive 4.5.32",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22a7ef7f676155edfb82daa97f99441f3ebf4a58d5e32f295a56259f1b6facc8"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex 0.7.4",
+ "strsim 0.11.1",
 ]
 
 [[package]]
@@ -761,6 +882,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_derive"
+version = "4.5.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "clap_lex"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -768,6 +901,12 @@ checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "clarity"
@@ -855,6 +994,12 @@ dependencies = [
  "once_cell",
  "owo-colors",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "colored"
@@ -984,9 +1129,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.2.11"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83bd3bb4314701c568e340cd8cf78c975aa0ca79e03d3f6d1677d5b0c9c0c03"
+checksum = "8658c15c5d921ddf980f7fe25b1e82f4b7a4083b2c4985fea4922edb8e43e07d"
 dependencies = [
  "generic-array 0.14.7",
  "rand_core 0.6.4",
@@ -1187,7 +1332,7 @@ dependencies = [
  "lazy_static",
  "regex",
  "serde",
- "strsim",
+ "strsim 0.10.0",
 ]
 
 [[package]]
@@ -1197,7 +1342,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43ee23aa5b4f68c7a092b5c3beb25f50c406adc75e2363634f242f28ab255372"
 dependencies = [
  "der 0.4.5",
- "elliptic-curve 0.10.6",
+ "elliptic-curve 0.10.4",
  "hmac",
  "signature",
 ]
@@ -1210,11 +1355,11 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.10.6"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beca177dcb8eb540133e7680baff45e7cc4d93bf22002676cec549f82343721b"
+checksum = "83e5c176479da93a0983f0a6fdc3c1b8e7d5be0d7fe3fe05a99f15b96582b9a8"
 dependencies = [
- "crypto-bigint 0.2.11",
+ "crypto-bigint 0.2.5",
  "ff",
  "generic-array 0.14.7",
  "group",
@@ -1819,11 +1964,11 @@ name = "gorc"
 version = "4.0.0"
 source = "git+https://github.com/PeggyJV/gravity-bridge?branch=main#4abf1076c280cf360e3aa51dced2113e52c146e0"
 dependencies = [
- "abscissa_core",
- "abscissa_tokio",
+ "abscissa_core 0.6.0",
+ "abscissa_tokio 0.6.0",
  "bip32",
  "bytes",
- "clap",
+ "clap 3.2.25",
  "clarity",
  "cosmos_gravity",
  "deep_space",
@@ -1845,7 +1990,7 @@ dependencies = [
  "signatory",
  "thiserror",
  "tokio",
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -1970,6 +2115,12 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -2267,6 +2418,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itertools"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2292,13 +2449,13 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.9.6"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "903ae2481bcdfdb7b68e0a9baa4b7c9aff600b9ae2e8e5bb5833b8c91ab851ea"
+checksum = "008b0281ca8032567c9711cd48631781c15228301860a39b32deb28d63125e46"
 dependencies = [
  "cfg-if",
  "ecdsa",
- "elliptic-curve 0.10.6",
+ "elliptic-curve 0.10.4",
  "sha2 0.9.9",
  "sha3 0.9.1",
 ]
@@ -3754,6 +3911,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3850,6 +4017,15 @@ checksum = "cb0652c533506ad7a2e353cce269330d6afd8bdfb6d75e0ace5b35aacbd7b9e9"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
  "serde",
 ]
 
@@ -4047,13 +4223,14 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 name = "steward"
 version = "4.2.7"
 dependencies = [
- "abscissa_core",
- "abscissa_tokio",
+ "abscissa_core 0.6.0",
+ "abscissa_core 0.8.2",
+ "abscissa_tokio 0.8.0",
  "addr",
  "assay",
  "bip32",
  "bytes",
- "clap",
+ "clap 4.5.32",
  "clarity",
  "deep_space",
  "ethers",
@@ -4094,7 +4271,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-util 0.7.10",
- "toml",
+ "toml 0.5.11",
  "tonic",
  "tonic-build",
  "tonic-reflection",
@@ -4118,6 +4295,12 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -4465,10 +4648,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.22.12",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -4478,7 +4676,7 @@ checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap 2.1.0",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.40",
 ]
 
 [[package]]
@@ -4489,7 +4687,20 @@ checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
  "indexmap 2.1.0",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3328d4f68a705b2a4498da1d580585d39a6510f98318a2cec3018a7ec61ddef"
+dependencies = [
+ "indexmap 2.1.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow 0.6.26",
 ]
 
 [[package]]
@@ -4771,6 +4982,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
@@ -5141,6 +5358,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "0.6.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5211,9 +5437,9 @@ checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zeroize"
-version = "1.4.3"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d68d9dcec5f9b43a30d38c49f91dfedfaac384cb8f085faca366c26207dd1619"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 dependencies = [
  "zeroize_derive",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4223,7 +4223,6 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 name = "steward"
 version = "4.2.7"
 dependencies = [
- "abscissa_core 0.6.0",
  "abscissa_core 0.8.2",
  "abscissa_tokio 0.8.0",
  "addr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,9 +72,7 @@ lazy_static = "1.4.0"
 # this crate. This allows for easy cross compiled builds because the 'vendored'
 # feature includes it's own OpenSSL version that's compiled on the fly
 # If ANY crate in this workspace has this it will work for all of them.
-openssl = { version = "=0.10.33", features = ["vendored"] }
-openssl-sys = "=0.9.61"
-openssl-probe = "0.1.4"
+openssl = { version = "=0.10.71", features = ["vendored"] }
 once_cell = "1.10.0"
 reqwest = "0.11.14"
 rustls = "0.19"
@@ -82,6 +80,8 @@ x509-parser = { version = "0.14.0", features = ["verify"] }
 rustls-pemfile = "1.0.2"
 tokio-util = "0.7.7"
 addr = "0.15.6"
+openssl-sys = "0.9.106"
+openssl-probe = "0.1.6"
 
 
 [dependencies.abscissa_core]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ version = "0.8.1"
 # features = ["gimli-backtrace"]
 
 [dev-dependencies]
-abscissa_core = { version = "0.6.0", features = ["testing"] }
+abscissa_core = { version = "0.8.1", features = ["testing"] }
 assay = "0.1"
 hex = "0.4.3"
 once_cell = "1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,10 +25,10 @@ edition.workspace = true
 rust-version = "1.76.0"
 
 [dependencies]
-abscissa_tokio = "0.6.0"
+abscissa_tokio = { version = "0.8.0", features = ["actix"] }
 bip32 = "0.2"
 bytes = "1.0"
-clap = "3"
+clap = "4"
 clarity = "0.4.12"
 deep_space = { git = "https://github.com/iqlusioninc/deep_space/", branch = "master" }
 ethers = { git = "https://github.com/iqlusioninc/ethers-rs.git", branch = "zaki/error_abi_support", features = [
@@ -85,7 +85,7 @@ addr = "0.15.6"
 
 
 [dependencies.abscissa_core]
-version = "0.6.0"
+version = "0.8.1"
 # optional: use `gimli` to capture backtraces
 # see https://github.com/rust-lang/backtrace-rs/issues/189
 # features = ["gimli-backtrace"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Reference: https://www.lpalmieri.com/posts/fast-rust-docker-builds/
 
 FROM rust:1.76-bullseye as cargo-chef-rust
-RUN cargo install cargo-chef --version 0.1.62
+RUN cargo install cargo-chef --version 0.1.62 --locked
 RUN rustup component add rustfmt
 
 FROM cargo-chef-rust as planner

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Reference: https://www.lpalmieri.com/posts/fast-rust-docker-builds/
 
-FROM rust:1.76-bullseye as cargo-chef-rust
+FROM rust:1.78-bullseye as cargo-chef-rust
 RUN cargo install cargo-chef --version 0.1.62 --locked
 RUN rustup component add rustfmt
 

--- a/src/cellars.rs
+++ b/src/cellars.rs
@@ -296,11 +296,11 @@ pub fn log_governance_cellar_call(
 // since a string prefixed with or without 0x is parsable, ensure the string comparison is valid
 pub fn normalize_address(address: String) -> String {
     let lowercase_address = address.to_lowercase();
-    return address
+    address
         .to_lowercase()
         .strip_prefix("0x")
         .unwrap_or(&lowercase_address)
-        .to_string();
+        .to_string()
 }
 
 // validation logic

--- a/src/commands/orchestrator/start.rs
+++ b/src/commands/orchestrator/start.rs
@@ -37,6 +37,7 @@ pub struct StartCommand {
 
 impl Runnable for StartCommand {
     fn run(&self) {
+        #[allow(deprecated)]
         openssl_probe::init_ssl_cert_env_vars();
 
         let config = APP.config();

--- a/src/commands/pubsub/add_publisher.rs
+++ b/src/commands/pubsub/add_publisher.rs
@@ -25,6 +25,7 @@ pub struct AddPublisherCmd {
 
 impl Runnable for AddPublisherCmd {
     fn run(&self) {
+        #[allow(deprecated)]
         openssl_probe::init_ssl_cert_env_vars();
 
         let data = std::fs::read_to_string(&self.ca_path).unwrap_or_else(|e| {

--- a/src/commands/pubsub/add_subscriber.rs
+++ b/src/commands/pubsub/add_subscriber.rs
@@ -19,6 +19,7 @@ pub struct AddSubscriberCmd {
 
 impl Runnable for AddSubscriberCmd {
     fn run(&self) {
+        #[allow(deprecated)]
         openssl_probe::init_ssl_cert_env_vars();
 
         let data = std::fs::read_to_string(&self.ca_path).unwrap_or_else(|e| {

--- a/src/commands/pubsub/subscribe.rs
+++ b/src/commands/pubsub/subscribe.rs
@@ -19,6 +19,7 @@ pub struct SubscribeCmd {
 
 impl Runnable for SubscribeCmd {
     fn run(&self) {
+        #[allow(deprecated)]
         openssl_probe::init_ssl_cert_env_vars();
 
         validate_url(&self.publisher_domain).unwrap_or_else(|e| {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Streamlined the process for standardizing address data, ensuring consistent behavior while maintaining existing functionality with no visible changes for end-users.
- **Chores**
	- Updated the base image version in the Dockerfile to enhance the environment and available features.
	- Modified the installation command for `cargo-chef` to include the `--locked` flag, promoting consistency in builds.
	- Improved clarity and maintainability of the Dockerfile by updating command syntax. 
- **Bug Fixes**
	- Suppressed compiler warnings related to deprecated methods in multiple command structures, ensuring smoother operation without altering existing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->