### PR TITLE
fix: Set default crypto provider for orch startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5485,7 +5485,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "steward"
-version = "4.3.1-pre"
+version = "4.3.2-pre"
 dependencies = [
  "abscissa_core",
  "abscissa_tokio",
@@ -5555,7 +5555,7 @@ dependencies = [
 
 [[package]]
 name = "steward-proto"
-version = "4.3.1-pre"
+version = "4.3.2-pre"
 dependencies = [
  "prost 0.13.5",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ exclude = ["server-test"]
 resolver = "2"
 
 [workspace.package]
-version = "4.3.1-pre"
+version = "4.3.2-pre"
 edition = "2021"
 
 [workspace.dependencies]

--- a/src/commands/orchestrator/start.rs
+++ b/src/commands/orchestrator/start.rs
@@ -41,6 +41,9 @@ impl Runnable for StartCommand {
         #[allow(deprecated)]
         openssl_probe::init_ssl_cert_env_vars();
 
+        // Set crypto provider
+        let _ = rustls::crypto::ring::default_provider().install_default();
+
         let config = APP.config();
         let cosmos_prefix = config.cosmos.prefix.clone();
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved the secure initialization process by setting up the cryptographic provider prior to configuration loading, reinforcing the application's overall security without altering its visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->